### PR TITLE
(Hotfix) remueve header en sección Matricula

### DIFF
--- a/server/routes/matricula.js
+++ b/server/routes/matricula.js
@@ -38,10 +38,6 @@ app.get('/', (req, res, next) => {
 
 
 app.get('/como-matricularse', (req, res, next) => {
-  console.log("JWT",req.headers);
-  if (req.headers.authorization){
-    wp.setHeaders('Authorization',req.headers.authorization);
-  }
   wp.pages().slug('como-matricularse').then(function(response){
     return res.status(200).json({info: response[0]});
   }).catch(function(err){
@@ -50,7 +46,6 @@ app.get('/como-matricularse', (req, res, next) => {
 });
 
 app.get('/baja-suspension', (req, res, next) => {
-  console.log("Params:",req.query);
   wp.pages().slug('baja-suspension').then(function(response){
     return res.status(200).json({info: response[0]});
   }).catch(function(err){


### PR DESCRIPTION
Matricula no requiere jwt para recuperar "como-matricularse" ni para "baja-suspension"